### PR TITLE
Token renewal on 401

### DIFF
--- a/duokey/client/client.go
+++ b/duokey/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/duokey/duokey-sdk-go/duokey"
@@ -130,6 +131,39 @@ func (c *Client) NewRequest(operation *request.Operation, params interface{}, da
 
 }
 
+// send a request, and if 401 update the token and send once again
+// To send the request a second time, it must be cloned
+// The result will be stored in the req.Response (also referenced in 'out' variable by the caller)
+func (c *Client) SendRequestWithTokenUpdate(req *request.Request) error {
+	err := req.Send()
+
+	if err == nil {
+		return nil
+	}
+
+	// Check if error 401, currently having to check for that string
+	// that is set in request.go parseHTTPResponse()
+	if strings.Contains(err.Error(), "request failed with status 401:") {
+		c.Config.Logger.Info("SendRequestWithTokenUpdate() 401 - renew Token and clone request to resend")
+		// renew the token and retry
+
+		err = c.renewToken()
+		if err != nil {
+			return err
+		}
+
+		clonedReq, err := req.CloneRequest(&c.Config)
+		if err != nil {
+			return err
+		}
+
+		return clonedReq.Send()
+	} else { // the error is not a token renewal problem, return it
+		return err
+	}
+
+}
+
 // GetMandatoryContext returns a map storing the context required by the DuoKey server for some of the calls (encryptRequest, decryptRequest, etc.)
 func (c *Client) GetMandatoryContext() map[string]string {
 	context := make(map[string]string)
@@ -150,6 +184,7 @@ func (c *Client) GetMandatoryContext() map[string]string {
 //	For machine-to-machine (M2M) communication where microservices access protected APIs, the Client Credentials Grant is the preferred method:
 //	When the Access Token expires, the microservice simply requests a new token using the same client credentials, without the need for a refresh token.
 func (c *Client) checkToken() error {
+	c.Config.Logger.Info("checkToken() - checking the current token")
 	renew := false
 
 	if c.Config.OAuth2Config == nil {
@@ -166,45 +201,53 @@ func (c *Client) checkToken() error {
 	}
 
 	if renew {
-		c.Config.Logger.Info("checkToken() - A new token is requested")
-		// The custom transport adds the tenant ID to the header
-		transport := &duoKeyTransport{
-			TenantID:       c.Config.Credentials.TenantID,
-			HeaderTenantID: c.Config.Credentials.HeaderTenantID,
-			Logger:         c.Config.Logger,
-		}
-
-		httpClient := &http.Client{Transport: transport, Timeout: c.Config.CheckTokenTimeOut}
-		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
-
-		// Password credentials call
-		token, err := c.Config.OAuth2Config.PasswordCredentialsToken(ctx, c.Config.Credentials.UserName, c.Config.Credentials.Password)
-		if err != nil {
-			c.Config.Logger.Infof("checkToken() - could not get the token: %v", err)
-			return err
-		}
-
-		// Token validation
-		if !token.Valid() {
-			c.Config.Logger.Infof("checkToken() - the new token is invalid")
-			return errors.New("checkToken() - the new token is invalid")
-		}
-
-		if token.TokenType != "Bearer" {
-			c.Config.Logger.Infof("checkToken() - bad token: expected 'Bearer', got '%s'", token.TokenType)
-			return errors.New("checkToken() - bad token: expected 'Bearer', got " + token.TokenType)
-		}
-
-		// Get an OAuth 2 client
-		oauth2Client := c.Config.OAuth2Config.Client(context.Background(), token)
-
-		// save the new token and Transport
-		c.Config.Token = token // store the token to check its validity before each call and manage expiration
-		c.Config.HTTPClient.Transport = oauth2Client.Transport
-		c.Config.Logger.Info("checkToken() - Token renewed")
+		return c.renewToken()
 	} else {
 		c.Config.Logger.Info("checkToken() - Token is still valid")
 	}
+
+	return nil
+}
+
+func (c *Client) renewToken() error {
+	c.Config.Logger.Info("renewToken() - A new token is requested")
+	// The custom transport adds the tenant ID to the header
+	transport := &duoKeyTransport{
+		TenantID:       c.Config.Credentials.TenantID,
+		HeaderTenantID: c.Config.Credentials.HeaderTenantID,
+		Logger:         c.Config.Logger,
+	}
+
+	httpClient := &http.Client{Transport: transport, Timeout: c.Config.CheckTokenTimeOut}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
+
+	var token *oauth2.Token
+	var err error
+	// Password credentials call
+	token, err = c.Config.OAuth2Config.PasswordCredentialsToken(ctx, c.Config.Credentials.UserName, c.Config.Credentials.Password)
+	if err != nil {
+		c.Config.Logger.Infof("renewToken() - could not get the token: %v", err)
+		return err
+	}
+
+	// Token validation
+	if !token.Valid() {
+		c.Config.Logger.Infof("renewToken() - the new token is invalid")
+		return errors.New("renewToken() - the new token is invalid")
+	}
+
+	if token.TokenType != "Bearer" {
+		c.Config.Logger.Infof("renewToken() - bad token: expected 'Bearer', got '%s'", token.TokenType)
+		return errors.New("renewToken() - bad token: expected 'Bearer', got " + token.TokenType)
+	}
+
+	// Get an OAuth 2 client
+	oauth2Client := c.Config.OAuth2Config.Client(context.Background(), token)
+
+	// save the new token and Transport
+	c.Config.Token = token // store the token to check its validity before each call and manage expiration
+	c.Config.HTTPClient.Transport = oauth2Client.Transport
+	c.Config.Logger.Info("renewToken() - Token renewed")
 
 	return nil
 }

--- a/duokey/request/request.go
+++ b/duokey/request/request.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -141,6 +142,9 @@ func parseHTTPResponse(resp *http.Response, response interface{}) error {
 		return errors.Wrap(err, "failed to read response body")
 	}
 
+	// Warning: some calling functions, to get the error StatusCode, will compare with the string returned currently
+	// For instance for 401, check if "request failed with status 401"
+	// Therefore be cautious if modifying this error's message
 	if resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(payload))
 	}
@@ -152,6 +156,32 @@ func parseHTTPResponse(resp *http.Response, response interface{}) error {
 	}
 
 	return nil
+}
+
+// CloneRequest cloning a request is useful when a request must be sent a
+// second time, for instance when the token has been renewed
+func (r *Request) CloneRequest(config *duokey.Config) (*Request, error) {
+	var bodyBytes []byte
+	if r.HTTPRequest.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(r.HTTPRequest.Body)
+		if err != nil {
+			return nil, err
+		}
+		r.HTTPRequest.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	cloneHTTPRequest := r.HTTPRequest.Clone(r.HTTPRequest.Context())
+	if bodyBytes != nil {
+		cloneHTTPRequest.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+	return &Request{
+		HTTPClient:  config.HTTPClient,
+		HTTPRequest: cloneHTTPRequest,
+		Error:       nil,
+		Parameters:  r.Parameters,
+		Response:    r.Response,
+	}, nil
 }
 
 // SetContext adds a context to a request.

--- a/service/kms/api.go
+++ b/service/kms/api.go
@@ -42,14 +42,14 @@ type ImportOutput struct {
 func (k *KMS) Import(input *ImportInput) (*ImportOutput, error) {
 	req, out := k.importRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) ImportWithContext(ctx context.Context, input *ImportInput) (*ImportOutput, error) {
 	req, out := k.importRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) importRequest(input *ImportInput) (req *request.Request, output *ImportOutput) {
@@ -127,7 +127,7 @@ func (k *KMS) CreateKey(input *CreateKeyInput) (*CreateKeyOutput, error) {
 
 	req, out := k.createKeyRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 // CreateKeyWithContext is the same operation as CreateKey. It is however possible
@@ -137,7 +137,7 @@ func (k *KMS) CreateKeyWithContext(ctx context.Context, input *CreateKeyInput) (
 	req, out := k.createKeyRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) createKeyRequest(input *CreateKeyInput) (req *request.Request, output *CreateKeyOutput) {
@@ -231,7 +231,7 @@ func (k *KMS) encryptRequest(input *EncryptInput, ctx context.Context) (*Encrypt
 			req.SetContext(ctx)
 		}
 
-		return out, req.Send()
+		return out, k.SendRequestWithTokenUpdate(req)
 	}
 }
 
@@ -362,7 +362,7 @@ func (k *KMS) Decrypt(input *DecryptInput) (*DecryptOutput, error) {
 
 	req, out := k.decryptRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 // DecryptWithContext is the same operation as Decrypt. It is however possible
@@ -372,7 +372,7 @@ func (k *KMS) DecryptWithContext(ctx context.Context, input *DecryptInput) (*Dec
 	req, out := k.decryptRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) decryptRequest(input *DecryptInput) (req *request.Request, output *DecryptOutput) {
@@ -463,7 +463,7 @@ func (k *KMS) GetKeyId(input *GetKeyIdInput) (*GetKeyOutput, error) {
 
 	req, out := k.getKeyIdRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 // GetKeyIdWithContext is the same operation as GetKeyId. It is however possible
@@ -473,7 +473,7 @@ func (k *KMS) GetKeyIdWithContext(ctx context.Context, input *GetKeyIdInput) (*G
 	req, out := k.getKeyIdRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) getKeyIdRequest(input *GetKeyIdInput) (req *request.Request, output *GetKeyOutput) {
@@ -513,7 +513,7 @@ func (k *KMS) GetKeyByName(input *GetKeyByNameInput) (*GetKeyOutput, error) {
 
 	req, out := k.getKeyByNameRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 // GetKeyByNameWithContext is the same operation as GetKeyByName. It is however possible
@@ -523,7 +523,7 @@ func (k *KMS) GetKeyByNameWithContext(ctx context.Context, input *GetKeyByNameIn
 	req, out := k.getKeyByNameRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) getKeyByNameRequest(input *GetKeyByNameInput) (req *request.Request, output *GetKeyOutput) {
@@ -565,7 +565,7 @@ func (k *KMS) DeleteKey(input *DeletekeyKeyInput) (*SuccessOutput, error) {
 
 	req, out := k.deleteKeyRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 // DeleteKeyWithContext is the same operation as DeleteKey. It is however possible
@@ -575,7 +575,7 @@ func (k *KMS) DeleteKeyWithContext(ctx context.Context, input *DeletekeyKeyInput
 	req, out := k.deleteKeyRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) deleteKeyRequest(input *DeletekeyKeyInput) (req *request.Request, output *SuccessOutput) {
@@ -629,7 +629,7 @@ type CSRImportOutput struct {
 func (k *KMS) CSRImport(input *CSRImportInput) (*CSRImportOutput, error) {
 	req, out := k.csrImportRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) CSRImportWithContext(ctx context.Context, input *CSRImportInput) (*CSRImportOutput, error) {
@@ -637,7 +637,7 @@ func (k *KMS) CSRImportWithContext(ctx context.Context, input *CSRImportInput) (
 	req, out := k.csrImportRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) csrImportRequest(input *CSRImportInput) (req *request.Request, output *CSRImportOutput) {
@@ -679,7 +679,7 @@ type CSRStatusOutput struct {
 func (k *KMS) CSRStatus(input *CSRStatusInput) (*CSRStatusOutput, error) {
 	req, out := k.csrStatusRequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) CSRStatusWithContext(ctx context.Context, input *CSRStatusInput) (*CSRStatusOutput, error) {
@@ -687,7 +687,7 @@ func (k *KMS) CSRStatusWithContext(ctx context.Context, input *CSRStatusInput) (
 	req, out := k.csrStatusRequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) csrStatusRequest(input *CSRStatusInput) (req *request.Request, output *CSRStatusOutput) {
@@ -727,7 +727,7 @@ type GetSignatureCAOutput struct {
 func (k *KMS) GetSignatureCA(input *GetSignatureCAInput) (*GetSignatureCAOutput, error) {
 	req, out := k.getSignatureCARequest(input)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) GetSignatureCAWithContext(ctx context.Context, input *GetSignatureCAInput) (*GetSignatureCAOutput, error) {
@@ -735,7 +735,7 @@ func (k *KMS) GetSignatureCAWithContext(ctx context.Context, input *GetSignature
 	req, out := k.getSignatureCARequest(input)
 	req.SetContext(ctx)
 
-	return out, req.Send()
+	return out, k.SendRequestWithTokenUpdate(req)
 }
 
 func (k *KMS) getSignatureCARequest(input *GetSignatureCAInput) (req *request.Request, output *GetSignatureCAOutput) {

--- a/service/kms/service_test.go
+++ b/service/kms/service_test.go
@@ -323,13 +323,31 @@ func newClientWithMockServer(credentials credentials.Config, endpoints Endpoints
 
 // newClientWithStandardMockServer() instanciate a standard mock server calling the defined mock routes
 // the kms client and the mock server are both returned -> the mock server will have to be closed
+// About 401 and token renewal:
+// This server will return a 401 on first call, and will answer as expected the second call
+//
+//	actually, it fires 401 when the global variable mockServerTokenErrorCounterFor401Simulation==0
+//	this global variable allows to tailor some tests.
+//
+// This is done to test that each route implemetentation does handle the 401 as expected:
+// In the current version of the SDK, if a 401 occurs, a new token is requested
+// and the query is cloned and resent a second time
+var mockServerTokenErrorCounterFor401Simulation = 0
+
 func newClientWithStandardMockServer(t *testing.T) (*KMS, *httptest.Server) {
 	const headerTenantID = "Abp.TenantId"
+	mockServerTokenErrorCounterFor401Simulation = 0
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload []byte
 		var err error
 		var body []byte
+
+		// Simulating a 401 on first call
+		if mockServerTokenErrorCounterFor401Simulation == 0 {
+			mockServerTokenErrorCounterFor401Simulation += 1
+			http.Error(w, "Unauthorized user", http.StatusUnauthorized)
+		}
 
 		tenantID := r.Header.Get(headerTenantID)
 		if tenantID == "" {
@@ -503,63 +521,8 @@ func newClientWithStandardMockServer(t *testing.T) (*KMS, *httptest.Server) {
 }
 
 func TestEncryptDecrypt(t *testing.T) {
-
-	const headerTenantID = "Abp.TenantId"
-
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var payload []byte
-		var err error
-		var body []byte
-
-		tenantID := r.Header.Get(headerTenantID)
-		if tenantID == "" {
-			t.Error("Tenant ID not found")
-		}
-		_, err = strconv.Atoi(tenantID)
-		if err != nil {
-			t.Error("TenantID: bad format")
-		}
-
-		if payload, err = ioutil.ReadAll(r.Body); err != nil {
-			t.Fail()
-		}
-
-		switch r.RequestURI {
-		case encryptRoute:
-			if body, err = mockEncrypt(payload); err != nil {
-				t.Fail()
-			}
-		case decryptRoute:
-			if body, err = mockDecrypt(payload); err != nil {
-				t.Fail()
-			}
-		default:
-			t.Fail()
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(body)
-	}))
+	kmsClient, mockServer := newClientWithStandardMockServer(t)
 	defer mockServer.Close()
-
-	endpoints := Endpoints{
-		BaseURL:      mockServer.URL,
-		EncryptRoute: encryptRoute,
-		DecryptRoute: decryptRoute,
-	}
-
-	credentials := credentials.Config{
-		Issuer:         endpoints.BaseURL,
-		ClientID:       "client",
-		ClientSecret:   uuid.New().String(),
-		UserName:       "jane.doe",
-		Password:       "tooManyS3cr3ts!",
-		Scope:          "key",
-		HeaderTenantID: headerTenantID,
-		TenantID:       1,
-	}
-
-	kmsClient := newClientWithMockServer(credentials, endpoints, mockServer.Client())
 
 	eInput := &EncryptInput{
 		KeyID:   uuid.New().String(),
@@ -578,12 +541,14 @@ func TestEncryptDecrypt(t *testing.T) {
 		Payload: eOutput.Result.EncryptedPayload,
 	}
 
+	mockServerTokenErrorCounterFor401Simulation = 0
+
 	dOutput, err := kmsClient.Decrypt(dInput)
 	if err != nil {
 		t.Fail()
+	} else {
+		assert.Equal(t, eInput.Payload, dOutput.Result.Payload, "The two plaintexts should be the same.")
 	}
-
-	assert.Equal(t, eInput.Payload, dOutput.Result.Payload, "The two plaintexts should be the same.")
 }
 
 func TestEncryptWithTimeout(t *testing.T) {


### PR DESCRIPTION
The token validity was already checked locally before any call.
However, nothing was done if the Cockpit returns a 401 because the token was somehow deprecated/canceled.
The request was just failing, and the next requests would fail too as the local token.valid() would still return true (this is just a test on the token expiry date).
Now a new token is requested when the Cockpit returns a 401, and the request is sent a second time.
This behavior is used in some Duokey code, avoiding to perform first a token validation by a Cockpit call, operation that would slow down each request.