### PR TITLE
Correction for mockCreateKey with the new CreateKeyOutput

### DIFF
--- a/service/kms/service_test.go
+++ b/service/kms/service_test.go
@@ -138,8 +138,9 @@ func mockCreateKey(body []byte) ([]byte, error) {
 		return nil, errors.New("Server Internal error")
 	}
 
-	output := SuccessOutput{
-		Success: true,
+	output := CreateKeyOutput{
+		Success:    true,
+		ExternalId: existingGuidId,
 	}
 
 	reply := &bytes.Buffer{}


### PR DESCRIPTION
A little while ago the CreateKey was updated to also return the ExternalId of the new key, with the new CreateKeyOutput.
But the test was not corrected accordingly